### PR TITLE
Add "application" concept and refactor

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -45,4 +45,4 @@ jobs:
         with:
           reporter: 'github-pr-review'
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          clippy_flags: --all-targets
+          clippy_flags: --workspace --all-targets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- (Breaking) The `up`/`down` sql strings are now tracked in the
+  database. This allows fly to know when a migration has been changed,
+  and how to un-apply an old or removed migration.
 - Integration tests and github CI.
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,6 +347,7 @@ name = "fly-migrate-core"
 version = "0.1.2"
 dependencies = [
  "postgres",
+ "postgres-types",
  "thiserror",
  "tracing",
 ]
@@ -655,6 +656,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "postgres-derive"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83145eba741b050ef981a9a1838c843fa7665e154383325aa8b440ae703180a2"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "postgres-protocol"
 version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -680,6 +693,7 @@ checksum = "8d2234cdee9408b523530a9b6d2d6b373d1db34f6a8e51dc03ded1828d7fb67c"
 dependencies = [
  "bytes",
  "fallible-iterator",
+ "postgres-derive",
  "postgres-protocol",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,6 +348,7 @@ version = "0.1.2"
 dependencies = [
  "postgres",
  "postgres-types",
+ "rand",
  "thiserror",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ anyhow = "1.0.81"
 tempfile = "3.10.1"
 thiserror = "1.0.58"
 postgres-types = { version = "0.2.6", features = ["derive"] }
+rand = "0.8.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ predicates = "3.1.0"
 anyhow = "1.0.81"
 tempfile = "3.10.1"
 thiserror = "1.0.58"
+postgres-types = { version = "0.2.6", features = ["derive"] }

--- a/fly-cli/src/main.rs
+++ b/fly-cli/src/main.rs
@@ -74,8 +74,7 @@ fn main() -> Result<()> {
             for migration in &migrations {
                 if !applied_migrations
                     .iter()
-                    .find(|m| m.migration.name == migration.name)
-                    .is_some()
+                    .any(|m| m.migration.name == migration.name)
                 {
                     info!("applying {}", migration.name);
                     debug!("{}", migration.up_sql);
@@ -109,18 +108,14 @@ fn main() -> Result<()> {
                 all_migrations.push(migration.clone())
             }
             for migration in applied_migrations.iter().map(|m| &m.migration) {
-                if !known_migrations.contains(&migration) {
+                if !known_migrations.contains(migration) {
                     all_migrations.push(migration.clone());
                 }
             }
             all_migrations.sort();
             for migration in all_migrations {
                 if known_migrations.contains(&migration) {
-                    if applied_migrations
-                        .iter()
-                        .find(|m| m.migration == migration)
-                        .is_some()
-                    {
+                    if applied_migrations.iter().any(|m| m.migration == migration) {
                         info!("{} [applied]", migration.name);
                     } else {
                         info!("{} [pending]", migration.name);

--- a/fly-cli/src/main.rs
+++ b/fly-cli/src/main.rs
@@ -3,7 +3,6 @@ use clap::Parser;
 use command::Command;
 use fly::config::Config;
 use fly::db::Db;
-use fly::migration::Migration;
 use std::{io::Write, time::SystemTime};
 use tracing::{debug, info, Level};
 
@@ -51,7 +50,7 @@ fn main() -> Result<()> {
         }
     );
 
-    let mut migrations = get_migrations(&config)?;
+    let mut migrations = fly::file::list(&config.migrate_dir)?;
     migrations.sort_by(|a, b| a.name.cmp(&b.name));
 
     debug!("migrations in migrations dir:");
@@ -139,23 +138,4 @@ fn main() -> Result<()> {
     }
 
     Ok(())
-}
-
-fn get_migrations(config: &Config) -> Result<Vec<Migration>> {
-    let mut migrations = Vec::new();
-
-    let paths = std::fs::read_dir(&config.migrate_dir).with_context(|| {
-        format!(
-            "problem reading migration directory ({})",
-            &config.migrate_dir.display()
-        )
-    })?;
-
-    for path in paths {
-        let path = path?.path();
-        let migration = Migration::from_file(&path)?;
-        migrations.push(migration);
-    }
-
-    Ok(migrations)
 }

--- a/fly-cli/tests/cli_test.rs
+++ b/fly-cli/tests/cli_test.rs
@@ -86,7 +86,7 @@ fn test_returns_ok() -> Result<()> {
     let database = common::TestDatabase::new()?;
 
     fs::write(
-        &env_file,
+        env_file,
         format!(
             r#"
 MIGRATE_DIR={migrate_dir}
@@ -123,7 +123,7 @@ fn test_accepts_pg_connection_string() -> Result<()> {
     let database = common::TestDatabase::new()?;
 
     fs::write(
-        &env_file,
+        env_file,
         format!(
             r#"
 MIGRATE_DIR={migrate_dir}
@@ -157,7 +157,7 @@ fn test_migrates_up_and_down() -> Result<()> {
     let database = common::TestDatabase::new()?;
 
     fs::write(
-        &env_file,
+        env_file,
         format!(
             r#"
 MIGRATE_DIR={migrate_dir}
@@ -195,7 +195,7 @@ PG_DB={database}
     let mut f = OpenOptions::new()
         .write(true)
         .create_new(false)
-        .open(&workdir.join(filename))?;
+        .open(workdir.join(filename))?;
 
     write!(
         &mut f,

--- a/fly-cli/tests/cli_test.rs
+++ b/fly-cli/tests/cli_test.rs
@@ -1,7 +1,13 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
+use assert_cmd::assert::Assert;
 use assert_cmd::prelude::*;
 use predicates::prelude::predicate;
-use std::{fs, process::Command};
+use std::io::Write;
+use std::path::Path;
+use std::{
+    fs::{self, OpenOptions},
+    process::Command,
+};
 use tempfile::tempdir;
 
 mod common;
@@ -138,6 +144,132 @@ PG_CONNECTION_STRING=postgres://{user}@{host}:{port}/{database}
     cmd.assert()
         .success()
         .stdout(predicate::str::contains("database is up to date"));
+
+    Ok(())
+}
+
+#[test]
+fn test_migrates_up_and_down() -> Result<()> {
+    let workdir = tempdir()?.into_path();
+    let env_file = workdir.join(".env");
+    let migrate_dir = workdir.join("migrations");
+    fs::create_dir(&migrate_dir)?;
+    let database = common::TestDatabase::new()?;
+
+    fs::write(
+        &env_file,
+        format!(
+            r#"
+MIGRATE_DIR={migrate_dir}
+PG_HOST={host}
+PG_USER={user}
+PG_PORT={port}
+PG_DB={database}
+"#,
+            migrate_dir = migrate_dir.to_string_lossy(),
+            host = database.host,
+            user = database.user,
+            port = database.port,
+            database = database.database
+        ),
+    )?;
+
+    let mut cmd = Command::cargo_bin("fly")?;
+    cmd.arg("new");
+    cmd.arg("create-users");
+    cmd.current_dir(&workdir);
+
+    let output = cmd.output()?;
+    let assert = Assert::new(output.clone());
+    assert
+        .success()
+        .stdout(predicate::str::contains("Created file"));
+
+    let output = String::from_utf8(output.stdout)?;
+    let (_, filename) = output
+        .rsplit_once(' ')
+        .ok_or(anyhow!("filename not found"))?;
+
+    let filename = filename.trim();
+
+    let mut f = OpenOptions::new()
+        .write(true)
+        .create_new(false)
+        .open(&workdir.join(filename))?;
+
+    write!(
+        &mut f,
+        "
+-- up
+create table users (id int);
+
+-- down
+drop table users;
+",
+    )
+    .unwrap();
+    drop(f);
+
+    let migration_name = Path::new(filename).file_name().unwrap().to_string_lossy();
+
+    let mut cmd = Command::cargo_bin("fly")?;
+    cmd.arg("up");
+    cmd.current_dir(&workdir);
+
+    let output = cmd.output()?;
+    let assert = Assert::new(output);
+    assert.success().stdout(predicate::str::contains(format!(
+        "applying {}",
+        migration_name
+    )));
+
+    let mut cmd = Command::cargo_bin("fly")?;
+    cmd.arg("status");
+    cmd.current_dir(&workdir);
+    let output = cmd.output()?;
+    let assert = Assert::new(output);
+    assert.success().stdout(predicate::str::contains(format!(
+        "{} [applied]",
+        migration_name
+    )));
+
+    let mut cmd = Command::cargo_bin("fly")?;
+    cmd.arg("down");
+    cmd.current_dir(&workdir);
+
+    let output = cmd.output()?;
+    let assert = Assert::new(output);
+    assert.success().stdout(predicate::str::contains(format!(
+        "reverting {}",
+        migration_name
+    )));
+
+    let mut cmd = Command::cargo_bin("fly")?;
+    cmd.arg("status");
+    cmd.current_dir(&workdir);
+    let output = cmd.output()?;
+    let assert = Assert::new(output);
+    assert.success().stdout(predicate::str::contains(format!(
+        "{} [pending]",
+        migration_name
+    )));
+
+    let mut cmd = Command::cargo_bin("fly")?;
+    cmd.arg("up");
+    cmd.current_dir(&workdir);
+    cmd.output().unwrap();
+
+    fs::remove_file(filename).unwrap();
+
+    let mut cmd = Command::cargo_bin("fly")?;
+    cmd.arg("status");
+    cmd.current_dir(&workdir);
+    let output = cmd.output()?;
+    let assert = Assert::new(output);
+    assert.success().stdout(predicate::str::contains(format!(
+        "{} ** NO FILE",
+        migration_name
+    )));
 
     Ok(())
 }

--- a/fly-core/Cargo.toml
+++ b/fly-core/Cargo.toml
@@ -15,3 +15,4 @@ path = "src/lib.rs"
 postgres.workspace = true
 tracing.workspace = true
 thiserror.workspace = true
+postgres-types.workspace = true

--- a/fly-core/Cargo.toml
+++ b/fly-core/Cargo.toml
@@ -16,3 +16,6 @@ postgres.workspace = true
 tracing.workspace = true
 thiserror.workspace = true
 postgres-types.workspace = true
+
+[dev-dependencies]
+rand.workspace = true

--- a/fly-core/src/config.rs
+++ b/fly-core/src/config.rs
@@ -1,4 +1,4 @@
-use crate::error::Error;
+use crate::error::{Error, Result};
 use std::{
     collections::HashMap,
     env,
@@ -27,7 +27,7 @@ impl Config {
         }
     }
 
-    pub fn from_env() -> Result<Self, Error> {
+    pub fn from_env() -> Result<Self> {
         let env_vars = env::vars().collect::<HashMap<String, String>>();
         let migrate_dir = get_env("MIGRATE_DIR", &env_vars)?.into();
         let debug = env_vars.get("DEBUG").unwrap_or(&"false".to_owned()) == "true";
@@ -41,7 +41,7 @@ impl Config {
     }
 }
 
-fn get_env(key: &str, vars: &HashMap<String, String>) -> Result<String, Error> {
+fn get_env(key: &str, vars: &HashMap<String, String>) -> Result<String> {
     vars.get(key)
         .map(|s| s.to_owned())
         .ok_or(Error::MissingEnv {
@@ -49,7 +49,7 @@ fn get_env(key: &str, vars: &HashMap<String, String>) -> Result<String, Error> {
         })
 }
 
-fn connection_string_from_env(env_vars: &HashMap<String, String>) -> Result<String, Error> {
+fn connection_string_from_env(env_vars: &HashMap<String, String>) -> Result<String> {
     if let Ok(connection_string) = get_env("PG_CONNECTION_STRING", env_vars) {
         Ok(connection_string)
     } else {

--- a/fly-core/src/db.rs
+++ b/fly-core/src/db.rs
@@ -36,7 +36,7 @@ impl Db {
         let migrations = rows
             .iter()
             .map(parse_migration_with_meta)
-            .collect::<Result<_, Error>>()?;
+            .collect::<Result<_, _>>()?;
         Ok(migrations)
     }
 

--- a/fly-core/src/db.rs
+++ b/fly-core/src/db.rs
@@ -33,7 +33,7 @@ impl Db {
         let rows = self.client.query("SELECT * FROM migrations", &[])?;
         let migrations = rows
             .iter()
-            .map(|row| MigrationWithMeta::try_from(row))
+            .map(MigrationWithMeta::try_from)
             .collect::<Result<_, Error>>()?;
         Ok(migrations)
     }

--- a/fly-core/src/db.rs
+++ b/fly-core/src/db.rs
@@ -35,9 +35,9 @@ impl Db {
         Ok(migrations)
     }
 
-    pub fn apply_migration(&mut self, sql: &str, migration: &Migration) -> Result<(), Error> {
+    pub fn apply_migration(&mut self, migration: &Migration) -> Result<(), Error> {
         let mut transaction = self.client.transaction()?;
-        transaction.batch_execute(sql)?;
+        transaction.batch_execute(&migration.up_sql)?;
         transaction.execute(
             "INSERT INTO migrations (name) VALUES ($1)",
             &[&migration.identifier],
@@ -46,9 +46,9 @@ impl Db {
         Ok(())
     }
 
-    pub fn rollback_migration(&mut self, sql: &str, migration: &Migration) -> Result<(), Error> {
+    pub fn rollback_migration(&mut self, migration: &Migration) -> Result<(), Error> {
         let mut transaction = self.client.transaction()?;
-        transaction.batch_execute(sql)?;
+        transaction.batch_execute(&migration.down_sql)?;
         transaction.execute(
             "DELETE FROM migrations WHERE name = $1",
             &[&migration.identifier],

--- a/fly-core/src/db.rs
+++ b/fly-core/src/db.rs
@@ -1,9 +1,8 @@
-use std::time::SystemTime;
-
 use crate::error::Result;
 use crate::migration::{Migration, MigrationMeta};
 use crate::{config::Config, migration::MigrationWithMeta};
 use postgres::{Client, NoTls, Row};
+use std::time::SystemTime;
 use tracing::debug;
 
 static CREATE_MIGRATIONS_TABLE: &str = r#"

--- a/fly-core/src/error.rs
+++ b/fly-core/src/error.rs
@@ -10,4 +10,6 @@ pub enum Error {
     MissingEnv { name: String },
     #[error("couldn't parse environment variable {name}")]
     BadEnvFormat { name: String },
+    #[error("bad filename {name}: {reason}")]
+    BadFilename { name: String, reason: String },
 }

--- a/fly-core/src/error.rs
+++ b/fly-core/src/error.rs
@@ -1,5 +1,7 @@
 use thiserror::Error;
 
+pub(crate) type Result<T> = core::result::Result<T, Error>;
+
 #[derive(Error, Debug)]
 pub enum Error {
     #[error(transparent)]

--- a/fly-core/src/error.rs
+++ b/fly-core/src/error.rs
@@ -16,4 +16,6 @@ pub enum Error {
     FilenameRequired,
     #[error("filename must be utf-8 encoded")]
     FilenameBadEncoding,
+    #[error("bad migration file format in {name}: {reason}")]
+    MigrationFileFormatError { reason: String, name: String },
 }

--- a/fly-core/src/error.rs
+++ b/fly-core/src/error.rs
@@ -8,8 +8,10 @@ pub enum Error {
     Io(#[from] std::io::Error),
     #[error("required environment variable {name} not set")]
     MissingEnv { name: String },
-    #[error("couldn't parse environment variable {name}")]
+    #[error("environment variable {name} could not be parsed")]
     BadEnvFormat { name: String },
-    #[error("bad filename {name}: {reason}")]
-    BadFilename { name: String, reason: String },
+    #[error("no filename given")]
+    FilenameRequired,
+    #[error("filename must be utf-8 encoded")]
+    FilenameBadEncoding,
 }

--- a/fly-core/src/file.rs
+++ b/fly-core/src/file.rs
@@ -1,8 +1,8 @@
-use crate::{error::Error, migration::Migration};
+use crate::{error::Error, error::Result, migration::Migration};
 use std::io::Read;
 use std::path::Path;
 
-pub fn list(migrate_dir: impl AsRef<Path>) -> Result<Vec<Migration>, Error> {
+pub fn list(migrate_dir: impl AsRef<Path>) -> Result<Vec<Migration>> {
     let paths = std::fs::read_dir(migrate_dir.as_ref())?;
 
     let mut migrations = Vec::new();
@@ -13,7 +13,7 @@ pub fn list(migrate_dir: impl AsRef<Path>) -> Result<Vec<Migration>, Error> {
     Ok(migrations)
 }
 
-fn parse_migration(path: impl AsRef<Path>) -> Result<Migration, Error> {
+fn parse_migration(path: impl AsRef<Path>) -> Result<Migration> {
     let name = path
         .as_ref()
         .file_name()

--- a/fly-core/src/file.rs
+++ b/fly-core/src/file.rs
@@ -8,12 +8,12 @@ pub fn list(migrate_dir: impl AsRef<Path>) -> Result<Vec<Migration>> {
     let mut migrations = Vec::new();
     for path in paths {
         let path = path?.path();
-        migrations.push(parse_migration(path)?);
+        migrations.push(parse_migration_from_file(path)?);
     }
     Ok(migrations)
 }
 
-fn parse_migration(path: impl AsRef<Path>) -> Result<Migration> {
+fn parse_migration_from_file(path: impl AsRef<Path>) -> Result<Migration> {
     let name = path
         .as_ref()
         .file_name()
@@ -21,31 +21,200 @@ fn parse_migration(path: impl AsRef<Path>) -> Result<Migration> {
         .to_str()
         .ok_or(Error::FilenameBadEncoding)?
         .to_string();
-    let mut file = std::fs::File::open(&path)?;
+    let file = std::fs::File::open(&path)?;
+    parse_migration(name, file)
+}
+
+fn parse_migration(name: String, mut reader: impl Read) -> Result<Migration> {
     let mut contents = String::new();
-    file.read_to_string(&mut contents)?;
+    reader.read_to_string(&mut contents)?;
     let mut statements = contents.split('\n');
     let mut up = String::new();
     let mut down = String::new();
+    let mut has_up = false;
+    let mut has_down = false;
     for line in &mut statements {
         if line == "-- up" {
+            if has_down {
+                return Err(Error::MigrationFileFormatError {
+                    reason: "up migration must come first".to_string(),
+                    name,
+                });
+            } else {
+                has_up = true;
+            }
             break;
         }
     }
     for line in &mut statements {
+        if line == "-- up" {
+            return Err(Error::MigrationFileFormatError {
+                reason: "only one up migration allowed".to_string(),
+                name,
+            });
+        }
         if line == "-- down" {
+            has_down = true;
             break;
         }
         up.push_str(line);
         up.push('\n');
     }
     for line in &mut statements {
+        if line == "-- down" {
+            return Err(Error::MigrationFileFormatError {
+                reason: "only one down migration allowed".to_string(),
+                name,
+            });
+        }
         down.push_str(line);
         down.push('\n');
     }
+
+    if !(has_down && has_up) {
+        return Err(Error::MigrationFileFormatError {
+            reason: "both up and down migrations must be defined".to_string(),
+            name,
+        });
+    }
     Ok(Migration {
-        up_sql: up,
-        down_sql: down,
+        up_sql: up.trim().to_string(),
+        down_sql: down.trim().to_string(),
         name,
     })
+}
+
+#[cfg(test)]
+mod test {
+    use std::io::Cursor;
+
+    use super::*;
+
+    #[test]
+    fn test_parse_migration_empty_string() -> Result<()> {
+        let migration_str = "".to_string();
+        let result = parse_migration("foo".to_string(), Cursor::new(migration_str));
+
+        assert!(result.is_err());
+        assert_eq!(
+            result.err().unwrap().to_string(),
+            "bad migration file format in foo: both up and down migrations must be defined"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_migration_just_up() -> Result<()> {
+        let migration_str = "
+-- up
+create table users (id int);
+"
+        .to_string();
+        let result = parse_migration("foo".to_string(), Cursor::new(migration_str));
+
+        assert!(result.is_err());
+        assert_eq!(
+            result.err().unwrap().to_string(),
+            "bad migration file format in foo: both up and down migrations must be defined"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_migration_just_down() -> Result<()> {
+        let migration_str = "
+-- down
+drop table users;
+"
+        .to_string();
+        let result = parse_migration("foo".to_string(), Cursor::new(migration_str));
+
+        assert!(result.is_err());
+        assert_eq!(
+            result.err().unwrap().to_string(),
+            "bad migration file format in foo: both up and down migrations must be defined"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_migration_multiple_ups() -> Result<()> {
+        let migration_str = "
+-- up
+create table users (id int);
+
+-- up
+alter table users add column is_active boolean default true;
+
+-- down
+drop table users;
+"
+        .to_string();
+        let result = parse_migration("foo".to_string(), Cursor::new(migration_str));
+
+        assert!(result.is_err());
+        assert_eq!(
+            result.err().unwrap().to_string(),
+            "bad migration file format in foo: only one up migration allowed"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_migration_multiple_downs() -> Result<()> {
+        let migration_str = "
+-- up
+create table users (id int);
+
+-- down
+alter table users remove column id;
+
+-- down
+drop table users;
+"
+        .to_string();
+        let result = parse_migration("foo".to_string(), Cursor::new(migration_str));
+
+        assert!(result.is_err());
+        assert_eq!(
+            result.err().unwrap().to_string(),
+            "bad migration file format in foo: only one down migration allowed"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_normal_migration() -> Result<()> {
+        let migration_str = "
+-- up
+create table users (
+  id int
+);
+
+-- down
+drop table users;
+"
+        .to_string();
+        let result = parse_migration("foo".to_string(), Cursor::new(migration_str));
+
+        assert!(result.is_ok());
+        assert_eq!(
+            result.ok().unwrap(),
+            Migration {
+                name: "foo".to_string(),
+                up_sql: "create table users (
+  id int
+);"
+                .to_string(),
+                down_sql: "drop table users;".to_string(),
+            }
+        );
+
+        Ok(())
+    }
 }

--- a/fly-core/src/file.rs
+++ b/fly-core/src/file.rs
@@ -1,0 +1,51 @@
+use crate::{error::Error, migration::Migration};
+use std::io::Read;
+use std::path::Path;
+
+pub fn list(migrate_dir: impl AsRef<Path>) -> Result<Vec<Migration>, Error> {
+    let paths = std::fs::read_dir(migrate_dir.as_ref())?;
+
+    let mut migrations = Vec::new();
+    for path in paths {
+        let path = path?.path();
+        migrations.push(parse_migration(path)?);
+    }
+    Ok(migrations)
+}
+
+fn parse_migration(path: impl AsRef<Path>) -> Result<Migration, Error> {
+    let name = path
+        .as_ref()
+        .file_name()
+        .ok_or(Error::FilenameRequired)?
+        .to_str()
+        .ok_or(Error::FilenameBadEncoding)?
+        .to_string();
+    let mut file = std::fs::File::open(&path)?;
+    let mut contents = String::new();
+    file.read_to_string(&mut contents)?;
+    let mut statements = contents.split('\n');
+    let mut up = String::new();
+    let mut down = String::new();
+    for line in &mut statements {
+        if line == "-- up" {
+            break;
+        }
+    }
+    for line in &mut statements {
+        if line == "-- down" {
+            break;
+        }
+        up.push_str(line);
+        up.push('\n');
+    }
+    for line in &mut statements {
+        down.push_str(line);
+        down.push('\n');
+    }
+    Ok(Migration {
+        up_sql: up,
+        down_sql: down,
+        name,
+    })
+}

--- a/fly-core/src/lib.rs
+++ b/fly-core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod config;
 pub mod db;
 pub mod error;
+pub mod file;
 pub mod migration;

--- a/fly-core/src/lib.rs
+++ b/fly-core/src/lib.rs
@@ -3,3 +3,4 @@ pub mod db;
 pub mod error;
 pub mod file;
 pub mod migration;
+pub mod planner;

--- a/fly-core/src/migration.rs
+++ b/fly-core/src/migration.rs
@@ -1,5 +1,4 @@
 use crate::error::Error;
-use postgres::Row;
 use std::{cmp::Ordering, io::Read, path::Path, time::SystemTime};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -31,29 +30,6 @@ pub struct MigrationMeta {
 pub struct MigrationWithMeta {
     pub migration: Migration,
     pub meta: MigrationMeta,
-}
-
-impl TryFrom<&Row> for MigrationWithMeta {
-    type Error = Error;
-
-    fn try_from(row: &Row) -> Result<Self, Self::Error> {
-        let up_sql = row.try_get::<_, String>("up_sql")?;
-        let down_sql = row.try_get::<_, String>("down_sql")?;
-        let name = row.try_get::<_, String>("name")?;
-
-        let migration = Migration {
-            up_sql,
-            down_sql,
-            name,
-        };
-
-        let id = row.try_get::<_, i32>("id")?;
-        let created_at = row.try_get::<_, SystemTime>("created_at")?;
-
-        let meta = MigrationMeta { id, created_at };
-
-        Ok(MigrationWithMeta { migration, meta })
-    }
 }
 
 impl Migration {

--- a/fly-core/src/migration.rs
+++ b/fly-core/src/migration.rs
@@ -1,5 +1,4 @@
-use crate::error::Error;
-use std::{cmp::Ordering, io::Read, path::Path, time::SystemTime};
+use std::{cmp::Ordering, time::SystemTime};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Migration {
@@ -30,44 +29,4 @@ pub struct MigrationMeta {
 pub struct MigrationWithMeta {
     pub migration: Migration,
     pub meta: MigrationMeta,
-}
-
-impl Migration {
-    /// Parse a `Migration` from a file.
-    pub fn from_file(path: impl AsRef<Path>) -> Result<Migration, Error> {
-        let name = path
-            .as_ref()
-            .file_name()
-            .ok_or(Error::FilenameRequired)?
-            .to_str()
-            .ok_or(Error::FilenameBadEncoding)?
-            .to_string();
-        let mut file = std::fs::File::open(&path)?;
-        let mut contents = String::new();
-        file.read_to_string(&mut contents)?;
-        let mut statements = contents.split('\n');
-        let mut up = String::new();
-        let mut down = String::new();
-        for line in &mut statements {
-            if line == "-- up" {
-                break;
-            }
-        }
-        for line in &mut statements {
-            if line == "-- down" {
-                break;
-            }
-            up.push_str(line);
-            up.push('\n');
-        }
-        for line in &mut statements {
-            down.push_str(line);
-            down.push('\n');
-        }
-        Ok(Migration {
-            up_sql: up,
-            down_sql: down,
-            name,
-        })
-    }
 }

--- a/fly-core/src/migration.rs
+++ b/fly-core/src/migration.rs
@@ -19,13 +19,13 @@ impl Ord for Migration {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MigrationMeta {
     pub id: i32,
     pub created_at: SystemTime,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MigrationWithMeta {
     pub migration: Migration,
     pub meta: MigrationMeta,

--- a/fly-core/src/migration.rs
+++ b/fly-core/src/migration.rs
@@ -1,28 +1,70 @@
 use crate::error::Error;
-use std::{io::Read, path::Path};
+use postgres::Row;
+use std::{cmp::Ordering, io::Read, path::Path, time::SystemTime};
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Migration {
     pub up_sql: String,
     pub down_sql: String,
-    pub identifier: String,
+    pub name: String,
+}
+
+impl PartialOrd for Migration {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.name.cmp(&other.name))
+    }
+}
+
+impl Ord for Migration {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.name.cmp(&other.name)
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct MigrationMeta {
+    pub id: i32,
+    pub created_at: SystemTime,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct MigrationWithMeta {
+    pub migration: Migration,
+    pub meta: MigrationMeta,
+}
+
+impl TryFrom<&Row> for MigrationWithMeta {
+    type Error = Error;
+
+    fn try_from(row: &Row) -> Result<Self, Self::Error> {
+        let up_sql = row.try_get::<_, String>("up_sql")?;
+        let down_sql = row.try_get::<_, String>("down_sql")?;
+        let name = row.try_get::<_, String>("name")?;
+
+        let migration = Migration {
+            up_sql,
+            down_sql,
+            name,
+        };
+
+        let id = row.try_get::<_, i32>("id")?;
+        let created_at = row.try_get::<_, SystemTime>("created_at")?;
+
+        let meta = MigrationMeta { id, created_at };
+
+        Ok(MigrationWithMeta { migration, meta })
+    }
 }
 
 impl Migration {
     /// Parse a `Migration` from a file.
     pub fn from_file(path: impl AsRef<Path>) -> Result<Migration, Error> {
-        let identifier = path
+        let name = path
             .as_ref()
             .file_name()
-            .ok_or_else(|| Error::BadFilename {
-                name: path.as_ref().to_string_lossy().to_string(),
-                reason: "requires a file name".to_string(),
-            })?
+            .ok_or(Error::FilenameRequired)?
             .to_str()
-            .ok_or_else(|| Error::BadFilename {
-                name: path.as_ref().to_string_lossy().to_string(),
-                reason: "not utf-8 encoded".to_string(),
-            })?
+            .ok_or(Error::FilenameBadEncoding)?
             .to_string();
         let mut file = std::fs::File::open(&path)?;
         let mut contents = String::new();
@@ -49,7 +91,7 @@ impl Migration {
         Ok(Migration {
             up_sql: up,
             down_sql: down,
-            identifier,
+            name,
         })
     }
 }

--- a/fly-core/src/planner.rs
+++ b/fly-core/src/planner.rs
@@ -1,0 +1,301 @@
+use crate::db::Db;
+use crate::error::Result;
+use crate::file;
+use crate::migration::{Migration, MigrationWithMeta};
+use std::collections::HashMap;
+use std::fmt::Display;
+use std::path::Path;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ApplicationState {
+    Pending {
+        definition: Migration,
+    },
+    Applied {
+        definition: Migration,
+        application: MigrationWithMeta,
+    },
+    Changed {
+        definition: Migration,
+        application: MigrationWithMeta,
+    },
+    Removed {
+        application: MigrationWithMeta,
+    },
+}
+
+impl ApplicationState {
+    pub fn is_pending(&self) -> bool {
+        match self {
+            ApplicationState::Pending { definition: _ } => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_applied(&self) -> bool {
+        match self {
+            ApplicationState::Applied {
+                definition: _,
+                application: _,
+            } => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_changed(&self) -> bool {
+        match self {
+            ApplicationState::Changed {
+                definition: _,
+                application: _,
+            } => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_removed(&self) -> bool {
+        match self {
+            ApplicationState::Removed { application: _ } => true,
+            _ => false,
+        }
+    }
+}
+
+impl Display for ApplicationState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ApplicationState::Pending { definition: file } => write!(f, "{} [pending]", file.name),
+            ApplicationState::Applied {
+                definition: file,
+                application: _,
+            } => {
+                write!(f, "{} [applied]", file.name)
+            }
+            ApplicationState::Changed {
+                definition: file,
+                application: _,
+            } => write!(f, "{} ** CHANGED **", file.name),
+            ApplicationState::Removed { application: db } => {
+                write!(f, "{} ** NO FILE **", db.migration.name)
+            }
+        }
+    }
+}
+
+pub fn get_all_migration_state(
+    db: &mut Db,
+    migrate_dir: impl AsRef<Path>,
+) -> Result<Vec<ApplicationState>> {
+    let definitions = file::list(migrate_dir.as_ref())?;
+    let applications = db.list()?;
+    Ok(get_all_migration_state_impl(definitions, applications))
+}
+
+fn get_all_migration_state_impl(
+    definitions: Vec<Migration>,
+    applications: Vec<MigrationWithMeta>,
+) -> Vec<ApplicationState> {
+    let definitions = definitions
+        .into_iter()
+        .map(|m| (m.name.clone(), m))
+        .collect::<HashMap<String, Migration>>();
+    let applications = applications
+        .into_iter()
+        .map(|m| (m.migration.name.clone(), m))
+        .collect::<HashMap<String, MigrationWithMeta>>();
+
+    let mut all_names = definitions
+        .iter()
+        .map(|(_, v)| v.name.clone())
+        .chain(applications.iter().map(|(_, v)| v.migration.name.clone()))
+        .collect::<Vec<String>>();
+    all_names.sort();
+    all_names.dedup();
+
+    all_names
+        .iter()
+        .map(|name| {
+            let definition = definitions.get(name);
+            let application = applications.get(name);
+
+            match (definition, application) {
+                (None, Some(application)) => ApplicationState::Removed {
+                    application: application.clone(),
+                },
+                (Some(definition), None) => ApplicationState::Pending {
+                    definition: definition.clone(),
+                },
+                (Some(definition), Some(application)) => {
+                    if application.migration == *definition {
+                        ApplicationState::Applied {
+                            definition: definition.clone(),
+                            application: application.clone(),
+                        }
+                    } else {
+                        ApplicationState::Changed {
+                            definition: definition.clone(),
+                            application: application.clone(),
+                        }
+                    }
+                }
+                (None, None) => unreachable!(),
+            }
+        })
+        .collect::<Vec<_>>()
+}
+
+#[cfg(test)]
+mod test {
+    use crate::migration::MigrationMeta;
+    use rand::seq::SliceRandom;
+    use std::time::SystemTime;
+
+    use super::*;
+
+    #[test]
+    fn test_get_all_migration_state_empty() {
+        let result = get_all_migration_state_impl(Vec::new(), Vec::new());
+        assert_eq!(result, Vec::new());
+    }
+
+    #[test]
+    fn test_get_all_migration_state_pending() {
+        let definition = build_migration("migration", "up", "down");
+        let result = get_all_migration_state_impl(vec![definition.clone()], Vec::new());
+        assert_eq!(
+            result,
+            vec![ApplicationState::Pending {
+                definition: definition
+            }]
+        );
+    }
+
+    #[test]
+    fn test_get_all_migration_state_removed() {
+        let application = build_migration_meta("migration", "up", "down");
+        let result = get_all_migration_state_impl(Vec::new(), vec![application.clone()]);
+        assert_eq!(
+            result,
+            vec![ApplicationState::Removed {
+                application: application
+            }]
+        );
+    }
+
+    #[test]
+    fn test_get_all_migration_state_applied() {
+        let definition = build_migration("migration", "up", "down");
+        let application = build_migration_meta("migration", "up", "down");
+        let result =
+            get_all_migration_state_impl(vec![definition.clone()], vec![application.clone()]);
+        assert_eq!(
+            result,
+            vec![ApplicationState::Applied {
+                definition: definition,
+                application: application
+            }]
+        );
+    }
+
+    #[test]
+    fn test_get_all_migration_up_state_changed() {
+        let definition = build_migration("migration", "up-changed", "down");
+        let application = build_migration_meta("migration", "up", "down");
+        let result =
+            get_all_migration_state_impl(vec![definition.clone()], vec![application.clone()]);
+        assert_eq!(
+            result,
+            vec![ApplicationState::Changed {
+                definition: definition,
+                application: application
+            }]
+        );
+    }
+
+    #[test]
+    fn test_get_all_migration_down_state_changed() {
+        let definition = build_migration("migration", "up", "down-changed");
+        let application = build_migration_meta("migration", "up", "down");
+        let result =
+            get_all_migration_state_impl(vec![definition.clone()], vec![application.clone()]);
+        assert_eq!(
+            result,
+            vec![ApplicationState::Changed {
+                definition: definition,
+                application: application
+            }]
+        );
+    }
+
+    #[test]
+    fn test_get_all_migration_state_multiple() {
+        let definition_a = build_migration("1-migration", "1-up", "1-down");
+        let definition_b = build_migration("2-migration", "2-up", "2-down");
+        let definition_c = build_migration("3-migration", "3-up", "3-down");
+
+        let application_a = build_migration_meta("1-migration", "1-up", "1-down");
+        let application_b = build_migration_meta("2-migration", "2-up-changed", "2-down");
+        let application_c = build_migration_meta("4-migration", "4-up", "4-down");
+
+        let mut definitions = vec![
+            definition_a.clone(),
+            definition_b.clone(),
+            definition_c.clone(),
+        ];
+        let mut applications = vec![
+            application_a.clone(),
+            application_b.clone(),
+            application_c.clone(),
+        ];
+
+        // The particular order of definitions/applications should not
+        // matter, as they are keyed and sorted by name.
+        let mut rng = rand::thread_rng();
+        definitions.shuffle(&mut rng);
+        applications.shuffle(&mut rng);
+
+        let result = get_all_migration_state_impl(definitions, applications);
+        assert_eq!(
+            result,
+            vec![
+                ApplicationState::Applied {
+                    definition: definition_a,
+                    application: application_a
+                },
+                ApplicationState::Changed {
+                    definition: definition_b,
+                    application: application_b
+                },
+                ApplicationState::Pending {
+                    definition: definition_c
+                },
+                ApplicationState::Removed {
+                    application: application_c
+                },
+            ]
+        );
+    }
+
+    fn build_migration(name: &'static str, up: &'static str, down: &'static str) -> Migration {
+        Migration {
+            up_sql: up.to_string(),
+            down_sql: down.to_string(),
+            name: name.to_string(),
+        }
+    }
+
+    fn build_migration_meta(
+        name: &'static str,
+        up: &'static str,
+        down: &'static str,
+    ) -> MigrationWithMeta {
+        let now = SystemTime::now();
+
+        MigrationWithMeta {
+            meta: MigrationMeta {
+                id: 123,
+                created_at: now,
+            },
+            migration: build_migration(name, up, down),
+        }
+    }
+}

--- a/fly-core/src/planner.rs
+++ b/fly-core/src/planner.rs
@@ -26,37 +26,19 @@ pub enum ApplicationState {
 
 impl ApplicationState {
     pub fn is_pending(&self) -> bool {
-        match self {
-            ApplicationState::Pending { definition: _ } => true,
-            _ => false,
-        }
+        matches!(self, ApplicationState::Pending { .. })
     }
 
     pub fn is_applied(&self) -> bool {
-        match self {
-            ApplicationState::Applied {
-                definition: _,
-                application: _,
-            } => true,
-            _ => false,
-        }
+        matches!(self, ApplicationState::Applied { .. })
     }
 
     pub fn is_changed(&self) -> bool {
-        match self {
-            ApplicationState::Changed {
-                definition: _,
-                application: _,
-            } => true,
-            _ => false,
-        }
+        matches!(self, ApplicationState::Changed { .. })
     }
 
     pub fn is_removed(&self) -> bool {
-        match self {
-            ApplicationState::Removed { application: _ } => true,
-            _ => false,
-        }
+        matches!(self, ApplicationState::Removed { .. })
     }
 }
 
@@ -104,9 +86,9 @@ fn get_all_migration_state_impl(
         .collect::<HashMap<String, MigrationWithMeta>>();
 
     let mut all_names = definitions
-        .iter()
-        .map(|(_, v)| v.name.clone())
-        .chain(applications.iter().map(|(_, v)| v.migration.name.clone()))
+        .values()
+        .map(|v| v.name.clone())
+        .chain(applications.values().map(|v| v.migration.name.clone()))
         .collect::<Vec<String>>();
     all_names.sort();
     all_names.dedup();


### PR DESCRIPTION
This introduces the concept of an "application" and `ApplicationState`
struct to represent the current state of a migration -- one of
pending, applied, changed or removed. We can then refactor the cli
`main` function quite a bit to operate over a vector of
`ApplicationState`.

To track whether a migration has been changed, or whether a migration
definition has been removed, we add up/down string columns to the
migrations table and store what these sql strings were at the time of
application. This will eventually allow us to revert old or removed migrations.

Also adds integration tests.