### PR TITLE
down command can recover from changed or removed migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - (Breaking) The `up`/`down` sql strings are now tracked in the
   database. This allows fly to know when a migration has been changed,
   and how to un-apply an old or removed migration.
+- `fly down` has the ability to recover from changed or removed
+  migrations with the `--recover` flag, along with other improvements.
 - Integration tests and github CI.
 
 ### Changed

--- a/fly-cli/src/command.rs
+++ b/fly-cli/src/command.rs
@@ -7,17 +7,28 @@ pub enum Command {
     Up,
 
     /// Rolls back the last migration.
-    Down,
+    Down {
+        /// If the migration is changed or removed, attempt to roll back using the down sql
+        /// string stored in the database. Cannot be used with `--ignore-changed`.
+        #[clap(short, long, default_value_t = false)]
+        recover: bool,
+
+        /// If the migration is changed, run the down sql defined in the migration file.
+        /// Cannot be used with `--recover`.
+        #[clap(short, long, default_value_t = false)]
+        ignore_changed: bool,
+
+        /// The name of the migration to roll back. If not provided, the default is to select
+        /// the latest non-pending migration.
+        name: Option<String>,
+    },
 
     /// Prints the current status of the database.
     Status,
 
     /// Creates a new migration file.
-    New(NewArgs),
-}
-
-#[derive(clap::Args, Debug)]
-pub struct NewArgs {
-    /// The name to use for the migration file, e.g., "create-users"
-    pub name: String,
+    New {
+        /// The name to use for the migration file, e.g., "create-users"
+        name: String,
+    },
 }

--- a/fly-core/src/planner.rs
+++ b/fly-core/src/planner.rs
@@ -40,6 +40,21 @@ impl ApplicationState {
     pub fn is_removed(&self) -> bool {
         matches!(self, ApplicationState::Removed { .. })
     }
+
+    pub fn name(&self) -> &str {
+        match self {
+            ApplicationState::Pending { definition } => &definition.name,
+            ApplicationState::Applied {
+                definition,
+                application: _,
+            } => &definition.name,
+            ApplicationState::Changed {
+                definition,
+                application: _,
+            } => &definition.name,
+            ApplicationState::Removed { application } => &application.migration.name,
+        }
+    }
 }
 
 impl Display for ApplicationState {


### PR DESCRIPTION
Adds a `--recover` flag to the `fly down` command. If the migration
we're rolling back has been changed, fly will run the down sql stored
in the database.

Also adds a `--ignore-changed` which will run the sql in the
definition file even in the presence of changes.