### PR TITLE
add example-env command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   and how to un-apply an old or removed migration.
 - `fly down` has the ability to recover from changed or removed
   migrations with the `--recover` flag, along with other improvements.
+- `fly example-env` outputs an example `.env` file.
 - Integration tests and github CI.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ to look in a `.env` file.
 - `PG_PORT`
 - `PG_DB`
 
+You can use the `example-env` subcommand to output an example `.env`
+file to get started:
+
+```
+fly example-env >> .env
+```
+
 You can also directly set a `PG_CONNECTION_STRING` instead of the
 individual `PG_` variables.
 
@@ -35,6 +42,7 @@ individual `PG_` variables.
 - `down`: Rolls back the last migration.
 - `status`: Prints the current status of the database.
 - `new`: Creates a new migration file.
+- `example-env`: Outputs an example `.env` file.
 
 [fly-migrate]: https://crates.io/crates/fly-migrate
 

--- a/fly-cli/src/command.rs
+++ b/fly-cli/src/command.rs
@@ -31,4 +31,7 @@ pub enum Command {
         /// The name to use for the migration file, e.g., "create-users"
         name: String,
     },
+
+    /// Outputs the contents of an example .env file to use with fly.
+    ExampleEnv,
 }

--- a/fly-core/src/config.rs
+++ b/fly-core/src/config.rs
@@ -9,34 +9,26 @@ use std::{
 pub struct Config {
     pub migrate_dir: PathBuf,
     pub connection_string: String,
-    pub debug: bool,
 }
 
 impl Config {
-    pub fn new(
-        migrate_dir: impl AsRef<Path>,
-        connection_string: impl AsRef<str>,
-        debug: bool,
-    ) -> Config {
+    pub fn new(migrate_dir: impl AsRef<Path>, connection_string: impl AsRef<str>) -> Config {
         let migrate_dir = migrate_dir.as_ref().to_path_buf();
         let connection_string = connection_string.as_ref().to_owned();
         Config {
             migrate_dir,
             connection_string,
-            debug,
         }
     }
 
     pub fn from_env() -> Result<Self> {
         let env_vars = env::vars().collect::<HashMap<String, String>>();
         let migrate_dir = get_env("MIGRATE_DIR", &env_vars)?.into();
-        let debug = env_vars.get("DEBUG").unwrap_or(&"false".to_owned()) == "true";
         let connection_string = connection_string_from_env(&env_vars)?;
 
         Ok(Config {
             migrate_dir,
             connection_string,
-            debug,
         })
     }
 }


### PR DESCRIPTION
This will output an example .env file that can be used to set up a new
project. E.g.,

```
fly example-env >> .env
```

Fixes #1.